### PR TITLE
Menambahkan button one click deploy to heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Setelah kode program didapatkan, buka terminal / command prompt, kemudian:
 
 Versi development dari aplikasi ini dideploy secara otomatis ke Heroku dan bisa diakses di [https://aplikasi-dosen.herokuapp.com/](https://aplikasi-dosen.herokuapp.com/)
 
+Tombol untuk 1 click deploy ke heroku :
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/idtazkia/aplikasi-dosen)
+
+
 ## Lisensi ##
 
 Aplikasi ini dirilis secara open-source dengan lisensi Apache License versi 2.0, yang [secara garis besar artinya sebagai berikut](https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)):

--- a/app.json
+++ b/app.json
@@ -1,0 +1,5 @@
+{
+    "name": "Aplikasi Dosen",
+    "description": "Aplikasi ini bertujuan untuk meringankan pekerjaan dosen yang berkaitan dengan pelaporan untuk Kemdikbud",
+    "keywords": ["spring boot", "java"]
+}


### PR DESCRIPTION
menambahkan app.json sebagai persyaratan untuk deploy ke heroku via one click button dan menambahkan button default one click deploy to heroku di readme.md agar mempermudah yang ingin deploy. Sudah di test bisa deploy menggunakan heroku free(hobby)